### PR TITLE
feat: サーバー実装の追加とパスエイリアスの更新

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "dependencies": {
         "@tanstack/react-router": "^1.112.0",
         "@tanstack/zod-adapter": "^1.112.0",
+        "hono": "^4.7.2",
         "lucide-react": "^0.477.0",
         "mapbox-gl": "^3.10.0",
         "react": "^19.0.0",
@@ -33,9 +34,19 @@
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react-swc": "^3.8.0",
+        "location-share-app-server": "workspace:*",
         "tailwindcss": "^4.0.9",
         "typescript": "^5.8.2",
         "vite": "^5.2.0",
+      },
+    },
+    "packages/server": {
+      "name": "location-share-app-server",
+      "dependencies": {
+        "hono": "^4.7.2",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
       },
     },
   },
@@ -410,6 +421,8 @@
 
     "grid-index": ["grid-index@1.1.0", "", {}, "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="],
 
+    "hono": ["hono@4.7.2", "", {}, "sha512-8V5XxoOF6SI12jkHkzX/6aLBMU5GEF5g387EjVSQipS0DlxWgWGSMeEayY3CRBjtTUQYwLHx9JYouWqKzy2Vng=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
@@ -461,6 +474,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.29.1", "", { "os": "win32", "cpu": "x64" }, "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q=="],
 
     "location-share-app-client": ["location-share-app-client@workspace:packages/client"],
+
+    "location-share-app-server": ["location-share-app-server@workspace:packages/server"],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@tanstack/react-router": "^1.112.0",
     "@tanstack/zod-adapter": "^1.112.0",
+    "hono": "^4.7.2",
     "lucide-react": "^0.477.0",
     "mapbox-gl": "^3.10.0",
     "react": "^19.0.0",
@@ -34,6 +35,7 @@
     "@vitejs/plugin-react-swc": "^3.8.0",
     "tailwindcss": "^4.0.9",
     "typescript": "^5.8.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "location-share-app-server": "workspace:*"
   }
 }

--- a/packages/client/src/hooks/index.tsx
+++ b/packages/client/src/hooks/index.tsx
@@ -1,0 +1,41 @@
+import { hc } from "hono/client";
+import type { WebSocketApp } from "location-share-app-server";
+import { useEffect } from "react";
+
+export const useSubscription = () => {
+  useEffect(() => {
+    const client = hc<WebSocketApp>("http://localhost:5000");
+    const socket = client.ws.$ws(); // A WebSocket object for a client
+
+    let intervalId: Timer;
+    socket.onopen = () => {
+      // 一定間隔でメッセージを送信
+      intervalId = setInterval(() => {
+        const message = JSON.stringify({
+          clientTime: new Date().toISOString(),
+        });
+        socket.send(message);
+      }, 3000);
+
+      // メッセージを受信
+      socket.onmessage = (event) => {
+        console.log(`Message from server: ${event.data}`);
+      };
+
+      // クリーンアップ時に送信を停止
+      return () => clearInterval(intervalId);
+    };
+
+    socket.onclose = () => {
+      console.log("closed");
+    };
+
+    // クリーンアップ関数
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      socket.close();
+    };
+  }, []);
+};

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -16,7 +16,7 @@
     "jsx": "react-jsx",
 
     "paths": {
-      "@/*": ["./src/*"]
+      "~/*": ["./src/*"]
     },
 
     /* Linting */

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -2,6 +2,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,4 +11,9 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  resolve: {
+    alias: {
+      "~": path.resolve(__dirname, "src"),
+    },
+  },
 });

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -1,0 +1,2 @@
+# deps
+node_modules/

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,11 @@
+To install dependencies:
+```sh
+bun install
+```
+
+To run:
+```sh
+bun run dev
+```
+
+open http://localhost:3000

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "location-share-app-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "bun run --hot src/index.ts"
+  },
+  "dependencies": {
+    "hono": "^4.7.2"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,33 @@
+import type { ServerWebSocket } from "bun";
+import { Hono } from "hono";
+import { createBunWebSocket } from "hono/bun";
+
+const app = new Hono();
+
+const { upgradeWebSocket, websocket } = createBunWebSocket<ServerWebSocket>();
+
+const webSocketApp = app.get(
+  "/ws",
+  upgradeWebSocket((c) => ({
+    onOpen: () => {
+      console.log("Connection opened");
+    },
+
+    onMessage(event, ws) {
+      console.log(`Message from client: ${event.data}`);
+      ws.send("Hello from server!");
+    },
+
+    onClose: () => {
+      console.log("Connection closed");
+    },
+  })),
+);
+
+export type WebSocketApp = typeof webSocketApp;
+
+export default {
+  fetch: app.fetch,
+  websocket,
+  port: 5000,
+};

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  },
+  "paths": {
+    "@/*": ["./src/*"]
+  }
+}


### PR DESCRIPTION
このコミットでは、Hono を使用したサーバー実装を追加し、クライアントのパスエイリアスを '@/*' から '~/*' に更新します。\n\nサーバー実装は、位置情報共有アプリのバックエンドロジックを提供します。\n\nパスエイリアスの更新により、クライアントコードベース全体でより一貫性のある柔軟なインポートが可能になります。